### PR TITLE
Add use_env_variable to production object

### DIFF
--- a/config/config.json
+++ b/config/config.json
@@ -16,11 +16,7 @@
         "dialect": "mysql"
     },
     "production": {
-        "username": "root",
-        "password": null,
-        "database": "database_production",
-        "host": "127.0.0.1",
-        "port": 3306,
+        "use_env_variable": "JAWSDB_URL",
         "dialect": "mysql"
     }
   }


### PR DESCRIPTION
Paste the following URL in .env file association with "production" object in config.json :
JAWSDB_URL:
mysql://yd2153ulooc1ipes:zwxrii4cjwj5cllv@rnr56s6e2uk326pj.cbetxkdyhwsb.us-east-1.rds.amazonaws.com:3306/yvqjdkmjsryuwbtt